### PR TITLE
Move actions off Node 20 runtimes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,15 +33,15 @@ jobs:
         language: [javascript-typescript]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -53,7 +53,7 @@ jobs:
             project_id_secret: VERCEL_PROJECT_ID_MYPROJECT1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Fail loudly but early if the deploy has never been configured, rather
       # than after a full Angular build.

--- a/.github/workflows/package-projects.yml
+++ b/.github/workflows/package-projects.yml
@@ -39,7 +39,7 @@ jobs:
             composer: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: shivammathur/setup-php@v2
         with:
@@ -95,7 +95,7 @@ jobs:
             -x '*.rar'
           ls -lh "_packages/${{ matrix.name }}.zip"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.name }}-package
           path: _packages/${{ matrix.name }}.zip

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -12,7 +12,7 @@ jobs:
     name: Quality scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Shallow clones stop Sonar attributing issues to the right commit.
           fetch-depth: 0


### PR DESCRIPTION
GitHub is deprecating Node 20 on Actions runners and already force-runs these on Node 24, so nothing was broken, but the affected actions were still declaring node20 and emitting the warning on every job.

actions/checkout v4 -> v5 and actions/upload-artifact v4 -> v5, the first majors on node24. github/codeql-action v3 -> v4 for the same reason. setup-node was already on v7.

Chose v5 rather than the current v7 for checkout and upload-artifact: v5 is what clears the deprecation, and these workflows use only the basic inputs (fetch-depth, name, path, retention-days), so there is nothing to gain from three more majors of churn. Dependabot tracks github-actions and will offer the rest with release notes attached.

All four workflow files still parse.