### PR TITLE
Deploy Angular apps to Vercel prebuilt, not via a second build

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -98,8 +98,30 @@ jobs:
             exit 1
           fi
 
-      - name: Deploy to Vercel
-        if: steps.creds.outputs.configured == 'true'
+      # The Angular apps are already built above. Deploying the output directory
+      # with a plain `vercel deploy` still triggers Vercel's own server-side
+      # build (the project's Angular preset runs `ng build`), which fails with
+      # exit 127 because there is no `ng` in a folder of static files. Instead,
+      # hand Vercel a Build Output API v3 bundle and deploy it with --prebuilt,
+      # which skips the build entirely and just serves the files.
+      - name: Deploy prebuilt bundle to Vercel
+        if: steps.creds.outputs.configured == 'true' && matrix.build
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets[matrix.project_id_secret] }}
+        run: |
+          npm install --global vercel@latest
+          staging="$(mktemp -d)"
+          mkdir -p "$staging/.vercel/output/static"
+          cp -R "${{ matrix.output }}/." "$staging/.vercel/output/static/"
+          printf '{"version":3}\n' > "$staging/.vercel/output/config.json"
+          cd "$staging"
+          vercel deploy --prebuilt --prod --yes --token="${{ secrets.VERCEL_TOKEN }}"
+
+      # html-css has no build step: it is already a static directory, and a
+      # plain deploy serves it as-is while honouring its .vercelignore.
+      - name: Deploy static site to Vercel
+        if: steps.creds.outputs.configured == 'true' && !matrix.build
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets[matrix.project_id_secret] }}


### PR DESCRIPTION
Both Angular deploys were failing with `ng build" exited with 127`. The workflow builds each app in CI (npm ci + npm run build) and then ran `vercel deploy <output-dir>`, but that still triggers Vercel's own server-side build: the project's Angular framework preset runs `ng build`, and there is no `ng` in a directory of already-built static files, so it exits 127. The app was being built twice — once correctly here, once broken on Vercel.

Now the built output is wrapped as a Build Output API v3 bundle (.vercel/output/static + config.json) and deployed with `vercel deploy --prebuilt`, which skips the build and just serves the files. This also stops depending on the project's dashboard framework setting.

html-css is unchanged: it has no build step, so a plain deploy still serves it directly and keeps honouring its .vercelignore. The two deploy steps split on matrix.build.

Not run here — there is no Vercel CLI or credentials in this environment. Verified that the workflow parses, that the build step already produces index.html at the top of each browser/ output (so it lands at the root of the static bundle), and that the matrix routes html-css to the static path and both Angular apps to --prebuilt.