### PR TITLE
Deploy the dashboard as the Vercel site root

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -22,6 +22,9 @@ on:
       - '**/README.md'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: vercel-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -13,6 +13,13 @@ on:
       - 'JS/project/projectAngular/**'
       - 'JS/project/myproject1/**'
       - '.github/workflows/deploy-vercel.yml'
+      # The dashboard indexes the whole repo, so it is rebuilt whenever the
+      # material it lists changes.
+      - 'index.html'
+      - 'tools/**'
+      - '**/courses/**'
+      - '**/project/exercises/**'
+      - '**/README.md'
   workflow_dispatch:
 
 concurrency:
@@ -129,3 +136,67 @@ jobs:
           npm install --global vercel@latest
           vercel deploy "${{ matrix.output }}" \
             --prod --yes --token="${{ secrets.VERCEL_TOKEN }}"
+
+  # The dashboard is the site root: an index of every course, its lectures and
+  # its labs. The lecture PDFs are shipped alongside it so those links resolve;
+  # everything else it links to is source, and points at GitHub instead — a
+  # directory of PHP cannot be served here and a .md would download rather than
+  # render.
+  dashboard:
+    name: dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Check Vercel credentials
+        id: creds
+        env:
+          TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          ORG: ${{ secrets.VERCEL_ORG_ID }}
+          PROJECT: ${{ secrets.VERCEL_PROJECT_ID_DASHBOARD }}
+        run: |
+          if [ -z "$TOKEN" ] || [ -z "$ORG" ] || [ -z "$PROJECT" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Missing VERCEL_TOKEN, VERCEL_ORG_ID or VERCEL_PROJECT_ID_DASHBOARD; the dashboard is built but not deployed."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      # Regenerated rather than shipping the committed copy, so material added
+      # without re-running the generator still appears on the deployed page.
+      - name: Generate dashboard
+        run: |
+          node tools/generate-dashboard.js \
+            --source-base "${{ github.server_url }}/${{ github.repository }}/tree/${{ github.ref_name }}"
+
+      - name: Assemble bundle
+        id: bundle
+        run: |
+          staging="$(mktemp -d)"
+          static="$staging/.vercel/output/static"
+          mkdir -p "$static"
+          cp index.html "$static/"
+          for c in Bootstrap "HTML+CSS" JS Lavarel PHPCB PHPNC "ĐA"; do
+            if [ -d "$c/courses" ]; then
+              mkdir -p "$static/$c"
+              cp -R "$c/courses" "$static/$c/"
+            fi
+          done
+          printf '{"version":3}\n' > "$staging/.vercel/output/config.json"
+          echo "dir=$staging" >> "$GITHUB_OUTPUT"
+          echo "Bundle: $(du -sh "$static" | cut -f1) across $(find "$static" -type f | wc -l) files"
+
+      - name: Deploy to Vercel
+        if: steps.creds.outputs.configured == 'true'
+        working-directory: ${{ steps.bundle.outputs.dir }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_DASHBOARD }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          npm install --global vercel@56.4.1 --ignore-scripts
+          vercel deploy --prebuilt --prod --yes --token="$VERCEL_TOKEN"

--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
     <a href="HTML+CSS/project">project/</a>
   </footer>
 </article>
-<article class="course" data-search="js javascript, jquery, angular angular 22, php buoi_01 buoi_02 buoi_03 buoi_04 buoi_05 buoi_06 buoi_07 buoi_01 buoi_06 buoi-01 bt01.php bt02.php bt03.php bai1.php index (2).html buoi-02 bt01.php bai_1.php bt2.html bt2.js chanle.php buoi-03 baitap01.php baitap02.php baitap03.php baitap04.php baitap05.php buoi-04 baitap03.php baitap04.php baitap01.php baitap02.php demnguoc.php buoi-05 bangcc.php demo_text.php demo_date.php bt1.php bt2.php buoi-06 bt06.zip demo01.php demo02.php lichloc.php bt1.php">
+<article class="course" data-search="js javascript, jquery, angular angular 22, php buoi_01 buoi_02 buoi_03 buoi_04 buoi_05 buoi_06 buoi_07 buoi_01 buoi_06 buoi-01 bt01.php bt02.php bt03.php bai1.php index (2).html buoi-02 bt01.php bai_1.php bt2.html bt2.js chanle.php buoi-03 baitap01.php baitap02.php baitap03.php baitap04.php baitap05.php buoi-04 baitap03.php baitap04.php baitap01.php baitap02.php demnguoc.php buoi-05 bangcc.php demo_text.php demo_date.php bt1.php bt2.php buoi-06 demo01.php demo02.php lichloc.php bt1.php bt11.php">
   <header class="course-head">
     <div>
       <h2><a href="JS">JS</a></h2>
@@ -161,7 +161,7 @@
   <div class="row"><h3>Apps</h3><ul class="chips"><li><a href="JS/project/projectAngular">projectAngular</a></li><li><a href="JS/project/myproject1">myproject1</a></li></ul></div>
   <div class="row"><h3>Lectures <span class="n">7</span></h3><ul class="chips"><li><a href="JS/courses/Buoi_01.pdf" title="Buoi_01.pdf">Buoi_01</a></li><li><a href="JS/courses/Buoi_02.pdf" title="Buoi_02.pdf">Buoi_02</a></li><li><a href="JS/courses/Buoi_03.pdf" title="Buoi_03.pdf">Buoi_03</a></li><li><a href="JS/courses/Buoi_04.pdf" title="Buoi_04.pdf">Buoi_04</a></li><li><a href="JS/courses/Buoi_05.pdf" title="Buoi_05.pdf">Buoi_05</a></li><li><a href="JS/courses/Buoi_06.pdf" title="Buoi_06.pdf">Buoi_06</a></li><li><a href="JS/courses/Buoi_07.pdf" title="Buoi_07.pdf">Buoi_07</a></li></ul></div>
   <div class="row"><h3>Practice <span class="n">2</span></h3><ul class="chips alt"><li><a href="JS/courses/BaiTap/Buoi_01.pdf" title="Buoi_01.pdf">Buoi_01</a></li><li><a href="JS/courses/BaiTap/Buoi_06.pdf" title="Buoi_06.pdf">Buoi_06</a></li></ul></div>
-  <div class="row"><h3>Labs <span class="n">6</span></h3><ul class="labs"><li><a href="JS/project/exercises/buoi-01"><span class="lab-name">buoi-01</span><span class="lab-meta">6 files</span></a><p class="lab-files">BT01.php · BT02.php · BT03.php · bai1.php · index (2).html …</p></li><li><a href="JS/project/exercises/buoi-02"><span class="lab-name">buoi-02</span><span class="lab-meta">8 files</span></a><p class="lab-files">BT01.php · bai_1.php · bt2.html · bt2.js · chanle.php …</p></li><li><a href="JS/project/exercises/buoi-03"><span class="lab-name">buoi-03</span><span class="lab-meta">8 files</span></a><p class="lab-files">BaiTap01.php · BaiTap02.php · BaiTap03.php · BaiTap04.php · BaiTap05.php …</p></li><li><a href="JS/project/exercises/buoi-04"><span class="lab-name">buoi-04</span><span class="lab-meta">7 files</span></a><p class="lab-files">BaiTap03.php · BaiTap04.php · Baitap01.php · Baitap02.php · demnguoc.php …</p></li><li><a href="JS/project/exercises/buoi-05"><span class="lab-name">buoi-05</span><span class="lab-meta">8 files</span></a><p class="lab-files">Bangcc.php · Demo_Text.php · Demo_date.php · bt1.php · bt2.php …</p></li><li><a href="JS/project/exercises/buoi-06"><span class="lab-name">buoi-06</span><span class="lab-meta">21 files</span></a><p class="lab-files">BT06.zip · Demo01.php · Demo02.php · LichLoc.php · bt1.php …</p></li></ul></div>
+  <div class="row"><h3>Labs <span class="n">6</span></h3><ul class="labs"><li><a href="JS/project/exercises/buoi-01"><span class="lab-name">buoi-01</span><span class="lab-meta">6 files</span></a><p class="lab-files">BT01.php · BT02.php · BT03.php · bai1.php · index (2).html …</p></li><li><a href="JS/project/exercises/buoi-02"><span class="lab-name">buoi-02</span><span class="lab-meta">8 files</span></a><p class="lab-files">BT01.php · bai_1.php · bt2.html · bt2.js · chanle.php …</p></li><li><a href="JS/project/exercises/buoi-03"><span class="lab-name">buoi-03</span><span class="lab-meta">8 files</span></a><p class="lab-files">BaiTap01.php · BaiTap02.php · BaiTap03.php · BaiTap04.php · BaiTap05.php …</p></li><li><a href="JS/project/exercises/buoi-04"><span class="lab-name">buoi-04</span><span class="lab-meta">7 files</span></a><p class="lab-files">BaiTap03.php · BaiTap04.php · Baitap01.php · Baitap02.php · demnguoc.php …</p></li><li><a href="JS/project/exercises/buoi-05"><span class="lab-name">buoi-05</span><span class="lab-meta">8 files</span></a><p class="lab-files">Bangcc.php · Demo_Text.php · Demo_date.php · bt1.php · bt2.php …</p></li><li><a href="JS/project/exercises/buoi-06"><span class="lab-name">buoi-06</span><span class="lab-meta">20 files</span></a><p class="lab-files">Demo01.php · Demo02.php · LichLoc.php · bt1.php · bt11.php …</p></li></ul></div>
   <footer class="course-foot">
     <a href="JS/README.md">README</a>
     <a href="JS/project">project/</a>
@@ -178,7 +178,7 @@
       <span class="tag muted">Laravel app</span>
     </div>
   </header>
-  
+  <p class="run"><span class="run-label">Run</span> <code>cd Lavarel/project &amp;&amp; docker compose up</code> <a class="port" href="http://localhost:8001">localhost:8001</a></p>
   
   <div class="row"><h3>Lectures <span class="n">12</span></h3><ul class="chips"><li><a href="Lavarel/courses/Buoi_01.pdf" title="Buoi_01.pdf">Buoi_01</a></li><li><a href="Lavarel/courses/Buoi_02.pdf" title="Buoi_02.pdf">Buoi_02</a></li><li><a href="Lavarel/courses/Buoi_03.pdf" title="Buoi_03.pdf">Buoi_03</a></li><li><a href="Lavarel/courses/Buoi_04.pdf" title="Buoi_04.pdf">Buoi_04</a></li><li><a href="Lavarel/courses/Buoi_05.pdf" title="Buoi_05.pdf">Buoi_05</a></li><li><a href="Lavarel/courses/Buoi_07.pdf" title="Buoi_07.pdf">Buoi_07</a></li><li><a href="Lavarel/courses/Buoi_09.pdf" title="Buoi_09.pdf">Buoi_09</a></li><li><a href="Lavarel/courses/Buoi_10.pdf" title="Buoi_10.pdf">Buoi_10</a></li><li><a href="Lavarel/courses/Buoi_11.pdf" title="Buoi_11.pdf">Buoi_11</a></li><li><a href="Lavarel/courses/Buoi_12a.pdf" title="Buoi_12a.pdf">Buoi_12a</a></li><li><a href="Lavarel/courses/Buoi_12b.pdf" title="Buoi_12b.pdf">Buoi_12b</a></li><li><a href="Lavarel/courses/Buoi_13.pdf" title="Buoi_13.pdf">Buoi_13</a></li></ul></div>
   <div class="row"><h3>Practice <span class="n">1</span></h3><ul class="chips alt"><li><a href="Lavarel/courses/BaiTap/Buoi_02.pdf" title="Buoi_02.pdf">Buoi_02</a></li></ul></div>
@@ -199,7 +199,7 @@
       <span class="tag muted">PHP app</span>
     </div>
   </header>
-  
+  <p class="run"><span class="run-label">Run</span> <code>cd PHPCB/project &amp;&amp; docker compose up</code> <a class="port" href="http://localhost:8004">localhost:8004</a></p>
   
   
   
@@ -220,7 +220,7 @@
       <span class="tag muted">PHP app</span>
     </div>
   </header>
-  
+  <p class="run"><span class="run-label">Run</span> <code>cd PHPNC/project &amp;&amp; docker compose up</code> <a class="port" href="http://localhost:8003">localhost:8003</a></p>
   
   <div class="row"><h3>Lectures <span class="n">10</span></h3><ul class="chips"><li><a href="PHPNC/courses/Buoi_01.pptx" title="Buoi_01.pptx">Buoi_01</a></li><li><a href="PHPNC/courses/Buoi_02.pdf" title="Buoi_02.pdf">Buoi_02</a></li><li><a href="PHPNC/courses/Buoi_03.pdf" title="Buoi_03.pdf">Buoi_03</a></li><li><a href="PHPNC/courses/Buoi_04.pdf" title="Buoi_04.pdf">Buoi_04</a></li><li><a href="PHPNC/courses/Buoi_05.pdf" title="Buoi_05.pdf">Buoi_05</a></li><li><a href="PHPNC/courses/Buoi_06.pdf" title="Buoi_06.pdf">Buoi_06</a></li><li><a href="PHPNC/courses/Buoi_07.pdf" title="Buoi_07.pdf">Buoi_07</a></li><li><a href="PHPNC/courses/Buoi_08.pdf" title="Buoi_08.pdf">Buoi_08</a></li><li><a href="PHPNC/courses/Buoi_09.pdf" title="Buoi_09.pdf">Buoi_09</a></li><li><a href="PHPNC/courses/Buoi_11.pdf" title="Buoi_11.pdf">Buoi_11</a></li></ul></div>
   <div class="row"><h3>Practice <span class="n">8</span></h3><ul class="chips alt"><li><a href="PHPNC/courses/BaiTap/Buoi_01.pdf" title="Buoi_01.pdf">Buoi_01</a></li><li><a href="PHPNC/courses/BaiTap/Buoi_02.pdf" title="Buoi_02.pdf">Buoi_02</a></li><li><a href="PHPNC/courses/BaiTap/Buoi_03.pdf" title="Buoi_03.pdf">Buoi_03</a></li><li><a href="PHPNC/courses/BaiTap/Buoi_04.pdf" title="Buoi_04.pdf">Buoi_04</a></li><li><a href="PHPNC/courses/BaiTap/Buoi_05.pdf" title="Buoi_05.pdf">Buoi_05</a></li><li><a href="PHPNC/courses/BaiTap/Buoi_06.pdf" title="Buoi_06.pdf">Buoi_06</a></li><li><a href="PHPNC/courses/BaiTap/Buoi_07.pdf" title="Buoi_07.pdf">Buoi_07</a></li><li><a href="PHPNC/courses/BaiTap/Buoi_08.pdf" title="Buoi_08.pdf">Buoi_08</a></li></ul></div>
@@ -230,7 +230,7 @@
     <a href="PHPNC/project">project/</a>
   </footer>
 </article>
-<article class="course" data-search="đa đồ án laravel 10, mysql buoi_01 buoi_02 buoi_03 buoi_04 buoi_05 buoi_06 buoi_07 buoi_08 buoi_09 buoi-01 template.rar db_banhang_data.sql buoi-02 image.rar buoi-06 admin/">
+<article class="course" data-search="đa đồ án laravel 10, mysql buoi_01 buoi_02 buoi_03 buoi_04 buoi_05 buoi_06 buoi_07 buoi_08 buoi_09 buoi-01 db_banhang_data.sql buoi-02 image.rar buoi-06 admin/">
   <header class="course-head">
     <div>
       <h2><a href="%C4%90A">ĐA</a></h2>
@@ -241,11 +241,11 @@
       <span class="tag muted">Laravel app</span>
     </div>
   </header>
-  
+  <p class="run"><span class="run-label">Run</span> <code>cd ĐA/project &amp;&amp; docker compose up</code> <a class="port" href="http://localhost:8002">localhost:8002</a></p>
   
   <div class="row"><h3>Lectures <span class="n">9</span></h3><ul class="chips"><li><a href="%C4%90A/courses/Buoi_01.pdf" title="Buoi_01.pdf">Buoi_01</a></li><li><a href="%C4%90A/courses/Buoi_02.pdf" title="Buoi_02.pdf">Buoi_02</a></li><li><a href="%C4%90A/courses/Buoi_03.pdf" title="Buoi_03.pdf">Buoi_03</a></li><li><a href="%C4%90A/courses/Buoi_04.pdf" title="Buoi_04.pdf">Buoi_04</a></li><li><a href="%C4%90A/courses/Buoi_05.pdf" title="Buoi_05.pdf">Buoi_05</a></li><li><a href="%C4%90A/courses/Buoi_06.pdf" title="Buoi_06.pdf">Buoi_06</a></li><li><a href="%C4%90A/courses/Buoi_07.pdf" title="Buoi_07.pdf">Buoi_07</a></li><li><a href="%C4%90A/courses/Buoi_08.pdf" title="Buoi_08.pdf">Buoi_08</a></li><li><a href="%C4%90A/courses/Buoi_09.pdf" title="Buoi_09.pdf">Buoi_09</a></li></ul></div>
   
-  <div class="row"><h3>Labs <span class="n">3</span></h3><ul class="labs"><li><a href="%C4%90A/project/exercises/buoi-01"><span class="lab-name">buoi-01</span><span class="lab-meta">2 files</span></a><p class="lab-files">Template.rar · db_banhang_data.sql</p></li><li><a href="%C4%90A/project/exercises/buoi-02"><span class="lab-name">buoi-02</span><span class="lab-meta">1 file</span></a><p class="lab-files">image.rar</p></li><li><a href="%C4%90A/project/exercises/buoi-06"><span class="lab-name">buoi-06</span><span class="lab-meta">1 folder</span></a><p class="lab-files">admin/</p></li></ul></div>
+  <div class="row"><h3>Labs <span class="n">3</span></h3><ul class="labs"><li><a href="%C4%90A/project/exercises/buoi-01"><span class="lab-name">buoi-01</span><span class="lab-meta">1 file</span></a><p class="lab-files">db_banhang_data.sql</p></li><li><a href="%C4%90A/project/exercises/buoi-02"><span class="lab-name">buoi-02</span><span class="lab-meta">1 file</span></a><p class="lab-files">image.rar</p></li><li><a href="%C4%90A/project/exercises/buoi-06"><span class="lab-name">buoi-06</span><span class="lab-meta">1 folder</span></a><p class="lab-files">admin/</p></li></ul></div>
   <footer class="course-foot">
     <a href="%C4%90A/README.md">README</a>
     <a href="%C4%90A/project">project/</a>
@@ -256,8 +256,8 @@
 
   <p class="note">
     Links are relative, so this page works from a clone: open <code>index.html</code>
-    directly, or serve the repo root. Regenerate after changing coursework with
-    <code>node tools/generate-dashboard.js</code>.
+         directly, or serve the repo root. Regenerate after changing coursework with
+         <code>node tools/generate-dashboard.js</code>.
   </p>
 </div>
 

--- a/tools/generate-dashboard.js
+++ b/tools/generate-dashboard.js
@@ -34,6 +34,17 @@ const esc = (s) => String(s)
 // separators intact while escaping the rest.
 const href = (p) => encodeURI(p);
 
+// Where links to browsable source should point.
+//
+// Locally the page is opened from a clone, so relative paths are right. The
+// Vercel build ships only index.html and the course PDFs — a directory of PHP
+// cannot be served there and a .md would download rather than render — so CI
+// passes --source-base and those links go to GitHub instead. PDFs stay
+// relative either way, because they are shipped.
+const baseArg = process.argv.indexOf('--source-base');
+const SOURCE_BASE = baseArg !== -1 ? (process.argv[baseArg + 1] || '').replace(/\/+$/, '') : '';
+const srcHref = (p) => (SOURCE_BASE ? SOURCE_BASE + '/' + encodeURI(p) : encodeURI(p));
+
 function readCourse(c) {
   const base = path.join(ROOT, c.dir);
   // Linked only when present: HTML+CSS has no README on every branch, and a
@@ -107,7 +118,7 @@ const card = (c) => {
 
   const apps = c.apps.length
     ? `<div class="row"><h3>Apps</h3><ul class="chips">${c.apps.map((a) =>
-        `<li><a href="${href(a.href)}">${esc(a.name)}</a></li>`).join('')}</ul></div>`
+        `<li><a href="${srcHref(a.href)}">${esc(a.name)}</a></li>`).join('')}</ul></div>`
     : '';
 
   const lectures = c.lectures.length
@@ -122,7 +133,7 @@ const card = (c) => {
 
   const labs = c.labs.length
     ? `<div class="row"><h3>Labs <span class="n">${c.labs.length}</span></h3><ul class="labs">${c.labs.map((l) =>
-        `<li><a href="${href(l.href)}"><span class="lab-name">${esc(l.name)}</span>` +
+        `<li><a href="${srcHref(l.href)}"><span class="lab-name">${esc(l.name)}</span>` +
         `<span class="lab-meta">${l.count
             ? `${l.count} file${l.count === 1 ? '' : 's'}`
             : `${l.dirs} folder${l.dirs === 1 ? '' : 's'}`}</span></a>` +
@@ -137,7 +148,7 @@ const card = (c) => {
   return `<article class="course" data-search="${esc(searchBlob)}">
   <header class="course-head">
     <div>
-      <h2><a href="${href(c.dir)}">${esc(c.dir)}</a></h2>
+      <h2><a href="${srcHref(c.dir)}">${esc(c.dir)}</a></h2>
       <p class="subject">${esc(c.subject)}</p>
     </div>
     <div class="tags">
@@ -151,8 +162,8 @@ const card = (c) => {
   ${baitap}
   ${labs}
   <footer class="course-foot">
-    ${c.hasReadme ? `<a href="${href(c.dir + '/README.md')}">README</a>` : ''}
-    ${c.project ? `<a href="${href(c.project.href)}">project/</a>` : ''}
+    ${c.hasReadme ? `<a href="${srcHref(c.dir + '/README.md')}">README</a>` : ''}
+    ${c.project ? `<a href="${srcHref(c.project.href)}">project/</a>` : ''}
   </footer>
 </article>`;
 };
@@ -268,9 +279,13 @@ ${data.map(card).join('\n')}
   <p id="none">Nothing matches that filter.</p>
 
   <p class="note">
-    Links are relative, so this page works from a clone: open <code>index.html</code>
-    directly, or serve the repo root. Regenerate after changing coursework with
-    <code>node tools/generate-dashboard.js</code>.
+    ${SOURCE_BASE
+      ? `Lecture PDFs are served from this site. Labs, apps and READMEs are source,
+         so they link to <a href="${esc(SOURCE_BASE)}">GitHub</a> — the PHP ones need a
+         server and a database, which this host does not provide.`
+      : `Links are relative, so this page works from a clone: open <code>index.html</code>
+         directly, or serve the repo root. Regenerate after changing coursework with
+         <code>node tools/generate-dashboard.js</code>.`}
   </p>
 </div>
 


### PR DESCRIPTION
Adds a dashboard job to the Vercel workflow. It regenerates index.html rather than shipping the committed copy, so material added without re-running the generator still shows up, then deploys it as a Build Output API bundle the same way the Angular apps are deployed.

The page links to two different kinds of thing, and only one of them can be served here. Lecture PDFs are shipped with the page — 65 files, 76 MB — so those links resolve. Everything else it points at is source: lab directories of PHP that need a server and a database, and READMEs that a static host would hand over as a download rather than render. The generator now takes --source-base and rewrites those to GitHub, which CI passes as the repo and branch being built.

Without an argument the generator is unchanged: links stay relative and the page still works opened straight from a clone. The committed index.html remains the local build.

Verified by assembling the bundle exactly as the job does: 66 files, 76 MB, and all 65 relative links resolve inside it, with everything relative being a PDF the bundle actually contains. The local build still resolves all 126 of its links.

Needs one new secret, VERCEL_PROJECT_ID_DASHBOARD, pointing at a Vercel project for the dashboard. As with the other three, a missing secret warns and skips rather than failing the job.