### PR TITLE
Run Angular tests under a no-sandbox Chrome and log report presence

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -50,11 +50,13 @@ jobs:
       - name: Generate Angular coverage
         if: steps.creds.outputs.configured == 'true'
         continue-on-error: true
+        timeout-minutes: 20
         run: |
           for app in JS/project/projectAngular JS/project/myproject1; do
             echo "::group::$app"
             ( npm --prefix "$app" ci --ignore-scripts && npm --prefix "$app" run test:ci ) \
               || echo "::warning::Angular tests failed for $app; its coverage will be missing"
+            echo "lcov: $(ls -l "$app/coverage/lcov.info" 2>/dev/null || echo MISSING)"
             echo "::endgroup::"
           done
 
@@ -77,6 +79,7 @@ jobs:
             ( composer --working-dir="$app" install --no-interaction --no-progress --no-scripts \
               && ( cd "$app" && vendor/bin/phpunit --testsuite=Unit --coverage-clover=coverage.xml ) ) \
               || echo "::warning::Laravel tests failed for $app; its coverage will be missing"
+            echo "clover: $(ls -l "$app/coverage.xml" 2>/dev/null || echo MISSING)"
             echo "::endgroup::"
           done
       # ------------------------------------------------------------------------

--- a/JS/project/myproject1/karma.conf.js
+++ b/JS/project/myproject1/karma.conf.js
@@ -32,6 +32,14 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    customLaunchers: {
+      // Chrome runs as root in CI; without --no-sandbox it fails to start and
+      // the run hangs, so ng test never produces coverage. Used by test:ci.
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu']
+      }
+    },
     browsers: ['Chrome'],
     singleRun: false,
     restartOnFileChange: true

--- a/JS/project/myproject1/package.json
+++ b/JS/project/myproject1/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "test:ci": "ng test --watch=false --code-coverage --browsers=ChromeHeadless",
+    "test:ci": "ng test --watch=false --code-coverage --browsers=ChromeHeadlessCI",
     "serve:ssr:myproject1": "node dist/myproject1/server/server.mjs"
   },
   "private": true,

--- a/JS/project/projectAngular/karma.conf.js
+++ b/JS/project/projectAngular/karma.conf.js
@@ -38,6 +38,14 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    customLaunchers: {
+      // Chrome runs as root in CI; without --no-sandbox it fails to start and
+      // the run hangs, so ng test never produces coverage. Used by test:ci.
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu']
+      }
+    },
     browsers: ['Chrome'],
     singleRun: false,
     restartOnFileChange: true

--- a/JS/project/projectAngular/package.json
+++ b/JS/project/projectAngular/package.json
@@ -7,7 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "test:ci": "ng test --watch=false --code-coverage --browsers=ChromeHeadless"
+    "test:ci": "ng test --watch=false --code-coverage --browsers=ChromeHeadlessCI"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Coverage was still 0% after the pipeline landed because the Angular suites almost certainly never completed in CI: karma's default ChromeHeadless launches Chrome with a sandbox, which fails when the runner executes as root, so `ng test` hangs until the job is killed and no lcov is written.

Add a ChromeHeadlessCI launcher (--no-sandbox --disable-gpu) to both karma configs and point the test:ci scripts at it, and cap the Angular step at 20 minutes so a hang can no longer stall the scan that follows.

Also echo `ls -l` of each expected lcov.info / coverage.xml right after it should have been produced, so the next run's log shows plainly which reports were generated and which are MISSING — turning the coverage black box into something diagnosable without local reproduction.