### PR TITLE
Add Prettier and PHP-CS-Fixer with a Format CI check

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,40 @@
+name: Format
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prettier:
+    name: Prettier
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+      # Advisory while the existing coursework is brought up to standard: this
+      # reports formatting drift without failing the build. Run `npm run format`
+      # locally to fix, then drop continue-on-error to enforce it.
+      - name: Check formatting
+        continue-on-error: true
+        run: npx --yes prettier@3 --check .
+
+  php-cs-fixer:
+    name: PHP-CS-Fixer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: '8.2'
+          tools: php-cs-fixer
+      # Advisory for the same reason; run `php-cs-fixer fix` locally to apply.
+      - name: Check PHP formatting
+        continue-on-error: true
+        run: php-cs-fixer fix --dry-run --diff

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,31 @@
+<?php
+
+// php-cs-fixer configuration for the hand-written PHP in this repo.
+//   Check:  php-cs-fixer fix --dry-run --diff
+//   Apply:  php-cs-fixer fix
+//
+// Vendored libraries, Composer dependencies, Blade templates and lecture
+// material are excluded so only the coursework's own PHP is touched. The rules
+// map onto the recurring Sonar findings: PSR-12 layout, no closing `?>` tag,
+// a single blank line at end of file, no trailing whitespace, brace placement
+// and `elseif` over `else if`.
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->name('*.php')
+    ->notName('*.blade.php')
+    ->exclude(['vendor', 'node_modules', 'bower_components', 'courses'])
+    ->notPath('#(pluto-1\.0\.0|ckeditor|polylang|Template/source|GiaoDien_Front|full-width-slider)#');
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(false)
+    ->setRules([
+        '@PSR12' => true,
+        'no_closing_tag' => true,
+        'single_blank_line_at_eof' => true,
+        'no_trailing_whitespace' => true,
+        'no_trailing_whitespace_in_comment' => true,
+        'braces_position' => true,
+        'control_structure_continuation_position' => true,
+        'elseif' => true,
+    ])
+    ->setFinder($finder);

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,33 @@
+# Dependencies and build output
+**/node_modules/
+**/vendor/
+**/bower_components/
+**/dist/
+**/coverage/
+_packages/
+.vercel/
+
+# Generated / minified
+**/*.min.js
+**/*.min.css
+**/*.map
+
+# Vendored third-party libraries bundled with the coursework
+**/pluto-1.0.0/
+**/ckeditor/
+**/polylang/
+**/Template_BootStrap/
+**/GiaoDien_Front/
+**/full-width-slider*/
+**/assets/dest/
+**/Template/source/
+
+# Lecture material
+**/courses/
+
+# PHP is formatted by php-cs-fixer, not Prettier (Prettier has no PHP parser)
+**/*.php
+
+# Lockfiles
+**/package-lock.json
+**/composer.lock

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "quoteProps": "as-needed",
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cce-hcmut",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Repo-level tooling only; each app builds from its own subdirectory.",
+  "scripts": {
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "devDependencies": {
+    "prettier": "^3.4.2"
+  }
+}


### PR DESCRIPTION
Set up repo-wide formatting so the recurring cosmetic Sonar findings (trailing whitespace, tabs, missing EOF newline, else-if, brace placement, stray ?> closing tags) can be fixed and kept fixed by tools rather than by hand:

- Prettier for JS/TS/HTML/CSS/JSON/YAML/MD (.prettierrc), with vendored libraries, build output and lecture material ignored (.prettierignore). Root package.json exposes `npm run format` / `format:check`.
- PHP-CS-Fixer (.php-cs-fixer.dist.php) for the hand-written PHP, PSR-12 plus the rules matching those findings; vendored/Blade/coursework paths excluded.
- A Format workflow runs both in check mode. Advisory (continue-on-error) for now since the existing coursework predates the tools; run `npm run format` and `php-cs-fixer fix`, then drop continue-on-error to enforce.